### PR TITLE
Fix Pointer class typo and add missing dependency bit-twiddle

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
   "dependencies": {
     "@fae/ecs": "^1.0.2",
     "ismobilejs": "^0.4.0",
-    "mini-signals": "^1.1.1"
+    "mini-signals": "^1.1.1",
+    "bit-twiddle": "^1.0.2"
   },
   "devDependencies": {
     "@englercj/code-style": "^1.0.6",

--- a/plugins/interaction/src/Pointer.js
+++ b/plugins/interaction/src/Pointer.js
@@ -409,7 +409,7 @@ export default class Pointer
         {
             this.type = data.pointerType;
         }
-        else if (event.type && event.type[0] === 'm')
+        else if (data.type && data.type[0] === 'm')
         {
             this.type = Pointer.TYPE.MOUSE;
         }


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/Fae/fae/blob/master/CONTRIBUTING.md
Code of Conduct: https://github.com/Fae/fae/blob/master/CODE_OF_CONDUCT.md
-->
##### Description of change

<!-- Provide a description of the change below this comment. -->

In Fae.interaction.Pointer "_set" method, changed else if (event.type && eventtype[0] === 'm') to else if (data.type && data.type[0] === 'm') as it is most likely a typo since there is no "event" object in the method. Interaction mouse move event throws an error in firefox because of this.

Add missing "bit-twiddle" dependency to "package.json".
##### Pre-Merge Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
